### PR TITLE
Refactor: Use GraphQL for wishlist product details

### DIFF
--- a/src/lib/queries/wishlistProduct.ts
+++ b/src/lib/queries/wishlistProduct.ts
@@ -1,0 +1,17 @@
+
+import { gql } from '@apollo/client';
+
+export const GET_WISHLIST_PRODUCT = gql`
+  query GetWishlistProduct($id: String!) {
+    product(id: $id) {
+      id
+      name
+      price
+      originalPrice
+      requiresPrescription
+      imageUrl
+      manufacturer
+      rating
+    }
+  }
+`;


### PR DESCRIPTION
Use GraphQL to fetch product details for the wishlist, optimizing the data retrieved.